### PR TITLE
Faster performance for decode function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -31,3 +31,6 @@ jobs:
 
     - name: Run tests
       run: npm test
+
+    - name: Run benchmarks
+      run: node benchmark/benchmark.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ dist
 coverage
 *.log
 node_modules/
+# Generated test data
+.nyc_output/
+*.pbf
+*.buf

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,6 @@
 .travis.yml
 .vscode/
 test/
+benchmark/
+.github/
+.nyc_output/

--- a/README.md
+++ b/README.md
@@ -4,24 +4,23 @@
 
 Topobuf is a compact binary encoding for topographic data.
 
-Topobuf provides _lossless_ compression of TopoJSON data into [protocol buffers](https://developers.google.com/protocol-buffers/).
+Topobuf provides _lossless_[^1] compression of [TopoJSON](https://github.com/topojson/topojson) data into [protocol buffers](https://developers.google.com/protocol-buffers/).
 Advantages over using JSON-based formats alone:
 
 - **Very compact**: typically makes TopoJSON 2-3 times smaller.
 - Smaller even when comparing gzipped sizes: 20-30% for TopoJSON.
+- Can store topology objects too large for `JSON.stringify` / `JSON.parse`
 - Can accommodate any TopoJSON data, including extensions with arbitrary properties.
 
 #### Sample compression sizes
-|                   | normal    | gzipped  |
-|-------------------|-----------|----------|
-| us-zips.json      | 101.85 MB | 26.67 MB |
-| us-zips.pbf       | 12.24 MB  | 10.48 MB |
-| us-zips.topo.json | 15.02 MB  | 3.19 MB  |
-| us-zips.topo.pbf  | 4.85 MB   | 2.72 MB  |
-| idaho.json        | 10.92 MB  | 2.57 MB  |
-| idaho.pbf         | 1.37 MB   | 1.17 MB  |
-| idaho.topo.json   | 1.9 MB    | 612 KB   |
-| idaho.topo.pbf    | 567 KB    | 479 KB   |
+|                       | normal   | gzipped |
+|-----------------------|----------|---------|
+| pa-census-blocks.json | 280 MB   | 44 MB   |
+| pa-census-blocks.pbf  | 114 MB   | 35 MB   |
+| us-zips.json          | 15.02 MB | 3.19 MB |
+| us-zips.pbf           | 4.85 MB  | 2.72 MB |
+| idaho.json            | 1.9 MB   | 612 KB  |
+| idaho.pbf             | 567 KB   | 479 KB  |
 
 
 ## Install
@@ -52,3 +51,5 @@ Given a [Pbf](https://github.com/mapbox/pbf) object with topobuf data, return a 
 ## See more
 
 This library is based on [`geobuf`](https://github.com/mapbox/geobuf) by Mapbox, which provides similar functionality for GeoJSON
+
+[^1]: When using [quantized TopoJSON](https://github.com/topojson/topojson-client/blob/master/README.md#quantize) - _nearly lossless_ otherwise

--- a/benchmark/benchmark.mjs
+++ b/benchmark/benchmark.mjs
@@ -1,0 +1,37 @@
+import { benchmark } from "@thi.ng/bench";
+import fs from "fs";
+import path from 'path';
+import Pbf from "pbf";
+import { fileURLToPath } from 'url';
+import { deserialize, serialize } from "v8";
+
+import * as topobuf from "../index.js";
+
+
+const __filename = fileURLToPath(import.meta.url);
+
+// Create serialized data to use in benchmark
+const json = JSON.parse(fs.readFileSync(path.dirname(__filename) + "/fixtures/de-census-blocks.json"));
+fs.writeFileSync(path.dirname(__filename) + "/fixtures/de-census-blocks.pbf", topobuf.encode(json, new Pbf()));
+fs.writeFileSync(path.dirname(__filename) + "/fixtures/de-census-blocks.buf", serialize(json));
+
+function getJSON(name) {
+  return JSON.parse(fs.readFileSync(path.dirname(__filename) + "/fixtures/" + name));
+}
+
+// Benchmark tests
+function runDecode() {
+  topobuf.decode(new Pbf(fs.readFileSync(path.dirname(__filename) + "/fixtures/de-census-blocks.pbf")));
+}
+
+function runDecodeV8() {
+  deserialize(fs.readFileSync(path.dirname(__filename) + "/fixtures/de-census-blocks.buf"));
+}
+
+function runParse() {
+  getJSON("de-census-blocks.json")
+}
+
+benchmark(runDecode, { title: "decode de census blocks (topobuf)", iter: 100, warmup: 5 });
+benchmark(runDecodeV8, { title: "decode de census blocks (v8)", iter: 100, warmup: 5 });
+benchmark(runParse, { title: "JSON.parse", iter: 100, warmup: 5 });

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 'use strict';
 
-exports.encode = require('./encode');
-exports.decode = require('./decode');
+exports.encode = require('./encode.js');
+exports.decode = require('./decode.js');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "topobuf",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "topobuf",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "@types/pbf": "^3.0.2",
@@ -14,6 +14,7 @@
         "pbf": "^3.2.1"
       },
       "devDependencies": {
+        "@thi.ng/bench": "^3.1.3",
         "jshint": "2.13.4",
         "tap": "^15.1.6"
       }
@@ -176,9 +177,9 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz",
-      "integrity": "sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==",
+      "version": "7.17.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.6.tgz",
+      "integrity": "sha512-2ULmRdqoOMpdvkbT8jONrZML/XALfzxlb052bldftkicAUy8AxSCkD5trDPQcwHNmolcl7wP6ehNqMlyUw6AaA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.16.7",
@@ -187,8 +188,8 @@
         "@babel/helper-split-export-declaration": "^7.16.7",
         "@babel/helper-validator-identifier": "^7.16.7",
         "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.16.7",
-        "@babel/types": "^7.16.7"
+        "@babel/traverse": "^7.17.3",
+        "@babel/types": "^7.17.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -372,6 +373,47 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@thi.ng/api": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/@thi.ng/api/-/api-8.3.3.tgz",
+      "integrity": "sha512-P7rnhwTvZYj6MZ8TG45Dv4E//FamDTj752qu6sZZr6OFy7+OTHditNdA03y+WWjp5lvCCnxDFcruRfgglS4wGg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/postspectacular"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/thing_umbrella"
+        }
+      ],
+      "engines": {
+        "node": ">=12.7"
+      }
+    },
+    "node_modules/@thi.ng/bench": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@thi.ng/bench/-/bench-3.1.3.tgz",
+      "integrity": "sha512-19WZlbwwklSsM1G2t3Qd2wqgEajZ+QuF2yeeAbFCNmvRKsLh38RN+yhPRObe3diWZuxW0ytkPbvMq1C/5iXxzg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/postspectacular"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/thing_umbrella"
+        }
+      ],
+      "dependencies": {
+        "@thi.ng/api": "^8.3.3"
+      },
+      "engines": {
+        "node": ">=12.7"
       }
     },
     "node_modules/@types/geojson": {
@@ -586,9 +628,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.2.tgz",
-      "integrity": "sha512-97XU1CTZ5TwU9Qy/Taj+RtiI6SQM1WIhZ9osT7EY0oO2aWXGABZT2OZeRL+6PfaQsiiMIjjwIoYFPq4APgspgQ==",
+      "version": "4.19.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.3.tgz",
+      "integrity": "sha512-XK3X4xtKJ+Txj8G5c30B4gsm71s69lqXlkYui4s6EkKxuv49qjYlY6oVd+IFJ73d4YymtM3+djvvt/R/iJwwDg==",
       "dev": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001312",
@@ -5011,9 +5053,9 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz",
-      "integrity": "sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==",
+      "version": "7.17.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.6.tgz",
+      "integrity": "sha512-2ULmRdqoOMpdvkbT8jONrZML/XALfzxlb052bldftkicAUy8AxSCkD5trDPQcwHNmolcl7wP6ehNqMlyUw6AaA==",
       "dev": true,
       "requires": {
         "@babel/helper-environment-visitor": "^7.16.7",
@@ -5022,8 +5064,8 @@
         "@babel/helper-split-export-declaration": "^7.16.7",
         "@babel/helper-validator-identifier": "^7.16.7",
         "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.16.7",
-        "@babel/types": "^7.16.7"
+        "@babel/traverse": "^7.17.3",
+        "@babel/types": "^7.17.0"
       }
     },
     "@babel/helper-simple-access": {
@@ -5162,6 +5204,21 @@
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "@thi.ng/api": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/@thi.ng/api/-/api-8.3.3.tgz",
+      "integrity": "sha512-P7rnhwTvZYj6MZ8TG45Dv4E//FamDTj752qu6sZZr6OFy7+OTHditNdA03y+WWjp5lvCCnxDFcruRfgglS4wGg==",
+      "dev": true
+    },
+    "@thi.ng/bench": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@thi.ng/bench/-/bench-3.1.3.tgz",
+      "integrity": "sha512-19WZlbwwklSsM1G2t3Qd2wqgEajZ+QuF2yeeAbFCNmvRKsLh38RN+yhPRObe3diWZuxW0ytkPbvMq1C/5iXxzg==",
+      "dev": true,
+      "requires": {
+        "@thi.ng/api": "^8.3.3"
       }
     },
     "@types/geojson": {
@@ -5339,9 +5396,9 @@
       }
     },
     "browserslist": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.2.tgz",
-      "integrity": "sha512-97XU1CTZ5TwU9Qy/Taj+RtiI6SQM1WIhZ9osT7EY0oO2aWXGABZT2OZeRL+6PfaQsiiMIjjwIoYFPq4APgspgQ==",
+      "version": "4.19.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.3.tgz",
+      "integrity": "sha512-XK3X4xtKJ+Txj8G5c30B4gsm71s69lqXlkYui4s6EkKxuv49qjYlY6oVd+IFJ73d4YymtM3+djvvt/R/iJwwDg==",
       "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30001312",

--- a/package.json
+++ b/package.json
@@ -26,13 +26,14 @@
   },
   "homepage": "https://github.com/azavea/topobuf",
   "devDependencies": {
+    "@thi.ng/bench": "^3.1.3",
     "jshint": "2.13.4",
     "tap": "^15.1.6"
   },
   "dependencies": {
-    "pbf": "^3.2.1",
     "@types/pbf": "^3.0.2",
-    "@types/topojson-specification": "^1.0.2"
+    "@types/topojson-specification": "^1.0.2",
+    "pbf": "^3.2.1"
   },
   "jshintConfig": {
     "trailing": true,

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -1,4 +1,4 @@
-var topobuf = require("../"),
+var topobuf = require("../index"),
   Pbf = require("pbf"),
   test = require("tap").test,
   fs = require("fs");


### PR DESCRIPTION
Techniques applied:
 - reuse values & prevP instead of assigning new arrays
 - use new Array() in cases where length is known ahead of time
 - prefer indexing over using .push() when possible
 - move array.length out of for-loops
 
 Benchmarks:
 DE - this is checked into the repo & run as part of GH Actions
 ```
benchmarking: decode de census blocks (topobuf improved)
        warmup... 1316.69ms (5 runs)
        total: 27744.31ms, runs: 100 (@ 1 calls/iter)
        mean: 277.44ms, median: 262.88ms, range: [237.97..370.11]
        q1: 249.41ms, q3: 311.62ms
        sd: 12.35%
 benchmarking: decode de census blocks (topobuf original)
        warmup... 1950.24ms (5 runs)
        total: 35306.07ms, runs: 100 (@ 1 calls/iter)
        mean: 353.06ms, median: 327.43ms, range: [287.10..504.32]
        q1: 314.84ms, q3: 374.80ms
        sd: 15.31%
benchmarking: decode de census blocks (v8)
        warmup... 1342.38ms (5 runs)
        total: 28516.00ms, runs: 100 (@ 1 calls/iter)
        mean: 285.16ms, median: 214.96ms, range: [179.42..500.37]
        q1: 205.45ms, q3: 419.76ms
        sd: 39.83%
benchmarking: JSON.parse
        warmup... 976.45ms (5 runs)
        total: 19386.82ms, runs: 100 (@ 1 calls/iter)
        mean: 193.87ms, median: 184.75ms, range: [160.75..272.58]
        q1: 172.84ms, q3: 218.48ms
        sd: 13.88%
```

PA was too big to check into git, so I just tested it locally

```
benchmarking: decode pa census blocks (topobuf improved)
        warmup... 29058.86ms (3 runs)
        total: 95192.60ms, runs: 15 (@ 1 calls/iter)
        mean: 6346.17ms, median: 6339.94ms, range: [6155.39..6574.00]
        q1: 6294.47ms, q3: 6487.87ms
        sd: 1.96%
benchmarking: decode pa census blocks (topobuf original)
        warmup... 32722.91ms (3 runs)
        total: 163888.58ms, runs: 15 (@ 1 calls/iter)
        mean: 10925.91ms, median: 10959.38ms, range: [10698.45..11060.15]
        q1: 10838.83ms, q3: 11033.05ms
        sd: 1.00%
benchmarking: decode pa census blocks (v8)
        warmup... 25402.78ms (3 runs)
        total: 130589.64ms, runs: 15 (@ 1 calls/iter)
        mean: 8705.98ms, median: 8657.52ms, range: [8445.19..8978.51]
        q1: 8625.25ms, q3: 8879.77ms
        sd: 1.71%
benchmarking: JSON.parse
        warmup... 17742.65ms (3 runs)
        total: 74554.91ms, runs: 15 (@ 1 calls/iter)
        mean: 4970.33ms, median: 5159.99ms, range: [4485.36..5388.14]
        q1: 4686.48ms, q3: 5264.77ms
        sd: 5.95%
```